### PR TITLE
add npm clean script to prevent error on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Node port of tripit/slate",
   "main": "index.js",
   "scripts": {
+    "clean": "rm -vrf build/*",
     "start": "gulp serve",
-    "build": "gulp",
-    "deploy": "./deploy.sh"
+    "build": "npm run clean && gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added `clean` script to remove all files in the `build/*` directory.

This fixes issue #7 .
